### PR TITLE
change deprecated ViewPropTypes to PropTypes

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { View, Animated, PanResponder, ViewPropTypes } from "react-native";
+import { View, Animated, PanResponder } from "react-native";
 import Defaults from "./Defaults";
 import clamp from "clamp";
 import { styles } from "./Styles";
@@ -14,8 +14,8 @@ let guid = 0;
 const actionShape = PropTypes.shape({
   show: PropTypes.bool,
   view: PropTypes.element, // takes priority over text + color
-  containerStyle: ViewPropTypes.style,
-  textStyle: ViewPropTypes.style,
+  containerStyle: PropTypes.style,
+  textStyle: PropTypes.style,
   text: PropTypes.string,
   color: PropTypes.string,
   onAction: PropTypes.func, // triggered on action, given card data, must return true if success
@@ -603,7 +603,7 @@ SwipeCards.propTypes = {
   onDragRelease: PropTypes.func,
   cardRemoved: PropTypes.func,
   renderCard: PropTypes.func.isRequired,
-  style: ViewPropTypes.style,
+  style: PropTypes.style,
   dragY: PropTypes.bool,
   smoothTransition: PropTypes.bool,
   keyExtractor: PropTypes.func.isRequired,


### PR DESCRIPTION
I used to have a problem in Expo's web view with this package. it was saying some stuff about ViewPropTypes. i did some research and tried a few solutions i found. last one worked.
Since [ViewPropTypes is removed](https://github.com/necolas/react-native-web/releases/tag/0.12.0) and [prop-types](https://github.com/facebook/prop-types) has a built-in _style_ property, i did the necessary modifications and everything appears to work just fine now.